### PR TITLE
reverted cancellation removal, now creating local promise library copy instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Below are is a sample of how to setup the loaders:
 2. `npm test`
 
 ## History
+* 1.0.3 - Reverted modal promise cancellation, fixed promise config overwrite errors instead
 * 1.0.2 - Removed unnecessary modal promise cancellation
 * 1.0.1 - Update to use postcss-calc 6
 * 1.0.0 - Switched to react-transition-group@1.x (for React 16)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-components-dialog",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-components-dialog",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "React material design modals",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Turns out, having a cancel option is a good idea! But, the promise config throws errors when promises are already used elsewhere. Therefore, I create a local copy of Bluebird's Promise library and set the config on that.